### PR TITLE
Add a code of conduct page

### DIFF
--- a/source/_nav.haml
+++ b/source/_nav.haml
@@ -13,6 +13,8 @@
         %li.nav-item
           = nav_link 'Local Companies using Ruby', '/wiki/companies_using_ruby_in_waterloo', class: "nav-link", active_if: %r{companies_using_ruby_in_waterloo}
         %li.nav-item
+          = nav_link 'Code of Conduct', '/wiki/code_of_conduct', class: "nav-link", active_if: %r{code_of_conduct}
+        %li.nav-item
           %a.nav-link(href='http://github.com/kwruby' rel='me') GitHub
         %li.nav-item
           %a.nav-link(href='https://twitter.com/kwrubydev' rel='me') Twitter

--- a/source/wiki/code_of_conduct.md
+++ b/source/wiki/code_of_conduct.md
@@ -1,0 +1,15 @@
+---
+title: Code of Conduct
+---
+
+KWRuby is dedicated to providing a harassment-free meetup experience for everyone. We do not tolerate harassment of meetup participants in any form. Sexual language and imagery is not appropriate for any meetup venue, including talks.Meetup participants violating these rules may be sanctioned or expelled from the meetup at the discretion of the meetup organizers.
+
+Harassment includes offensive verbal comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+
+**Participants asked to stop any harassing behavior are expected to comply immediately.**
+
+If a participant engages in harassing behavior, the meetup organizers may take any action they deem appropriate, including warning the offender or expulsion from the meetup. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of meetup staff immediately.
+
+Meetup staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the meetup. We value your attendance.
+
+You can contact the organizer in person at meetups or privately via the email `mail at andrewsullivancant dot ca`.

--- a/source/wiki/code_of_conduct.md
+++ b/source/wiki/code_of_conduct.md
@@ -2,7 +2,7 @@
 title: Code of Conduct
 ---
 
-KWRuby is dedicated to providing a harassment-free meetup experience for everyone. We do not tolerate harassment of meetup participants in any form. Sexual language and imagery is not appropriate for any meetup venue, including talks.Meetup participants violating these rules may be sanctioned or expelled from the meetup at the discretion of the meetup organizers.
+KWRuby is dedicated to providing a harassment-free meetup experience for everyone. We do not tolerate harassment of meetup participants in any form. Sexual language and imagery is not appropriate for any meetup venue, including talks. Meetup participants violating these rules may be sanctioned or expelled from the meetup at the discretion of the meetup organizers.
 
 Harassment includes offensive verbal comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
 


### PR DESCRIPTION
The content was based on http://www.austinonrails.org/code_of_conduct.

<img width="1674" alt="Screen Shot 2019-12-30 at 8 03 28 AM" src="https://user-images.githubusercontent.com/2293178/71583077-ec111100-2ada-11ea-8e1d-699513d47b0f.png">

The intention of this page is to be a start of a code of conduct so we can make the group more save for all people now and improve it overtime.

Thanks =)